### PR TITLE
BZ 3438: Fix mismatched response of Device API

### DIFF
--- a/swagger2.0/oic.r.cloudapiforcloudservices.swagger.json
+++ b/swagger2.0/oic.r.cloudapiforcloudservices.swagger.json
@@ -270,9 +270,9 @@
         ],
         "responses": {
           "200": {
-            "description": "Device requested with content=all query parameter",
+            "description": "Device requested with content=base query parameter",
             "schema": {
-              "$ref": "#/definitions/DeviceContentAll"
+              "$ref": "#/definitions/Device"
             }
           },
           "400": {


### PR DESCRIPTION
- querystring is "content=base", but DeviceContenAll is used for response